### PR TITLE
Tenacity fix

### DIFF
--- a/target_benchmark/retrievers/llama_index/embedding_utils.py
+++ b/target_benchmark/retrievers/llama_index/embedding_utils.py
@@ -7,7 +7,7 @@ import pandas as pd
 from openai import OpenAI
 from pydantic import BaseModel, Field
 from sqlalchemy import Column, Engine, MetaData, String, Table, inspect
-from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 
 class TableInfo(BaseModel):
@@ -57,10 +57,7 @@ class DuplicateTableNameError(Exception):
 
 @retry(
     reraise=True,
-    retry=(
-        retry_if_exception(json.JSONDecodeError)
-        | retry_if_exception(DuplicateTableNameError),
-    ),
+    retry=retry_if_exception_type(exception_types=(json.JSONDecodeError, DuplicateTableNameError)),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=4, max=32),
 )


### PR DESCRIPTION
When running any function that called `get_table_info_from_lm`, I ran into the following error raised by tenacity:

```
self.iter_state.retry_run_result = self.retry(retry_state)
TypeError: 'tuple' object is not callable
```

This was caused by this line in the tenacity decorator:

```python
retry=(
        retry_if_exception(json.JSONDecodeError)
        | retry_if_exception(DuplicateTableNameError),
    )
```

Taking a look at the documentation and source code, it looks like the `retry` arg should be a callable. They provide their own for our usecase:

```python
retry=retry_if_exception_type(exception_types=(json.JSONDecodeError, DuplicateTableNameError))
```

@jixy2012 was the previous version working for you? I'm on `tenacity== 8.5.0`