### PR TITLE
feat: adding a demo notebook

### DIFF
--- a/demo/demo_notebook.ipynb
+++ b/demo/demo_notebook.ipynb
@@ -2,17 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "from target_benchmark.evaluators import TARGET\n",
-    "from target_benchmark.retrievers import AbsCustomEmbeddingRetriever"
+    "from target_benchmark.retrievers import AbsCustomEmbeddingRetriever\n",
+    "from target_benchmark.tasks import TableRetrievalTask\n",
+    "from target_benchmark.dataset_loaders.TargetDatasetConfig import DEFAULT_SPIDER_TEST_DATASET_CONFIG"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,18 +23,32 @@
     "        return [(\"0\", \"0\")] * top_k\n",
     "\n",
     "    def embed_corpus(self, dataset_name, corpus):\n",
+    "        corp_len = 0\n",
+    "        for entry in corpus:\n",
+    "            corp_len += 1\n",
+    "        print(corp_len)\n",
     "        return"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spider_5_tables = DEFAULT_SPIDER_TEST_DATASET_CONFIG.model_copy()\n",
+    "spider_5_tables.num_tables = 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "09feee95fdbc4e23aa961996d913c8c1",
+       "model_id": "4507c6f5e2d6430eb3a7262b6e3d99da",
        "version_major": 2,
        "version_minor": 0
       },
@@ -44,31 +60,39 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Retrieving Tables for spider-test...: 100%|██████████| 2147/2147 [00:00<00:00, 15185.27it/s]\n"
+      "Retrieving Tables for spidert-test...: 100%|██████████| 2147/2147 [00:00<00:00, 15137.06it/s]\n"
      ]
     }
    ],
    "source": [
-    "target = TARGET((\"Table Retrieval Task\", \"spider-test\"))\n",
+    "table_retrieval_task = TableRetrievalTask({\"spidert-test\": spider_5_tables})\n",
+    "target = TARGET(table_retrieval_task)\n",
     "retriever = DummyRetriever()\n",
     "retrieval_results = target.run(retriever=retriever)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'Table Retrieval Task': {'spider-test': TaskResultsDataModel(retrieval_performance=RetrievalPerformanceDataModel(k=5, accuracy=0.0, precision=None, recall=0.0, retrieval_duration_process=0.02078, avg_retrieval_duration_process=1e-05, retrieval_duration_wall_clock=0.01968, avg_retrieval_duration_wall_clock=1e-05), downstream_task_performance=DownstreamTaskPerformanceDataModel(task_name=None, scores=None), embedding_statistics=EmbeddingStatisticsDataModel(embedding_creation_duration_process=1e-05, avg_embedding_creation_duration_process=0.0, embedding_creation_duration_wall_clock=1e-05, avg_embedding_creation_duration_wall_clock=0.0, embedding_size=0.0, avg_embedding_size=0.0))}}"
+       "{'Table Retrieval Task': {'spidert-test': TaskResultsDataModel(retrieval_performance=RetrievalPerformanceDataModel(k=5, accuracy=0.0, precision=None, recall=0.0, retrieval_duration_process=0.02078, avg_retrieval_duration_process=1e-05, retrieval_duration_wall_clock=0.01985, avg_retrieval_duration_wall_clock=1e-05), downstream_task_performance=DownstreamTaskPerformanceDataModel(task_name=None, scores=None), embedding_statistics=EmbeddingStatisticsDataModel(embedding_creation_duration_process=1e-05, avg_embedding_creation_duration_process=0.0, embedding_creation_duration_wall_clock=0.0, avg_embedding_creation_duration_wall_clock=0.0, embedding_size=0.0, avg_embedding_size=0.0))}}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/demo/demo_notebook.ipynb
+++ b/demo/demo_notebook.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from target_benchmark.evaluators import TARGET\n",
+    "from target_benchmark.retrievers import AbsCustomEmbeddingRetriever"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DummyRetriever(AbsCustomEmbeddingRetriever):\n",
+    "    def retrieve(self, query, dataset_name, top_k, **kwargs):\n",
+    "        return [(\"0\", \"0\")] * top_k\n",
+    "\n",
+    "    def embed_corpus(self, dataset_name, corpus):\n",
+    "        return"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "09feee95fdbc4e23aa961996d913c8c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 132 files:   0%|          | 0/132 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Retrieving Tables for spider-test...: 100%|██████████| 2147/2147 [00:00<00:00, 15185.27it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "target = TARGET((\"Table Retrieval Task\", \"spider-test\"))\n",
+    "retriever = DummyRetriever()\n",
+    "retrieval_results = target.run(retriever=retriever)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Table Retrieval Task': {'spider-test': TaskResultsDataModel(retrieval_performance=RetrievalPerformanceDataModel(k=5, accuracy=0.0, precision=None, recall=0.0, retrieval_duration_process=0.02078, avg_retrieval_duration_process=1e-05, retrieval_duration_wall_clock=0.01968, avg_retrieval_duration_wall_clock=1e-05), downstream_task_performance=DownstreamTaskPerformanceDataModel(task_name=None, scores=None), embedding_statistics=EmbeddingStatisticsDataModel(embedding_creation_duration_process=1e-05, avg_embedding_creation_duration_process=0.0, embedding_creation_duration_wall_clock=1e-05, avg_embedding_creation_duration_wall_clock=0.0, embedding_size=0.0, avg_embedding_size=0.0))}}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "retrieval_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "target",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/demo/demo_notebook.ipynb
+++ b/demo/demo_notebook.ipynb
@@ -2,19 +2,27 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
+     ]
+    }
+   ],
    "source": [
     "from target_benchmark.evaluators import TARGET\n",
-    "from target_benchmark.retrievers import AbsCustomEmbeddingRetriever\n",
+    "from target_benchmark.retrievers import AbsCustomEmbeddingRetriever, HNSWOpenAIEmbeddingRetriever\n",
     "from target_benchmark.tasks import TableRetrievalTask\n",
     "from target_benchmark.dataset_loaders.TargetDatasetConfig import DEFAULT_SPIDER_TEST_DATASET_CONFIG"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,13 +50,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optionally for using openai embeddings. \n",
+    "# this should create corpus embeddings once and reuse it for later, but i don't have code to persist query embeddings yet. if it would be helpful, i can quickly try to add some query embedding persistence code.\n",
+    "# retriever = HNSWOpenAIEmbeddingRetriever()\n",
+    "retriever = DummyRetriever()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4507c6f5e2d6430eb3a7262b6e3d99da",
+       "model_id": "de7dfb9ff292447f979302ab087ac488",
        "version_major": 2,
        "version_minor": 0
       },
@@ -70,29 +90,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Retrieving Tables for spidert-test...: 100%|██████████| 2147/2147 [00:00<00:00, 15137.06it/s]\n"
+      "Retrieving Tables for spidert-test...: 100%|██████████| 2147/2147 [00:00<00:00, 10968.34it/s]\n"
      ]
     }
    ],
    "source": [
     "table_retrieval_task = TableRetrievalTask({\"spidert-test\": spider_5_tables})\n",
     "target = TARGET(table_retrieval_task)\n",
-    "retriever = DummyRetriever()\n",
     "retrieval_results = target.run(retriever=retriever)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'Table Retrieval Task': {'spidert-test': TaskResultsDataModel(retrieval_performance=RetrievalPerformanceDataModel(k=5, accuracy=0.0, precision=None, recall=0.0, retrieval_duration_process=0.02078, avg_retrieval_duration_process=1e-05, retrieval_duration_wall_clock=0.01985, avg_retrieval_duration_wall_clock=1e-05), downstream_task_performance=DownstreamTaskPerformanceDataModel(task_name=None, scores=None), embedding_statistics=EmbeddingStatisticsDataModel(embedding_creation_duration_process=1e-05, avg_embedding_creation_duration_process=0.0, embedding_creation_duration_wall_clock=0.0, avg_embedding_creation_duration_wall_clock=0.0, embedding_size=0.0, avg_embedding_size=0.0))}}"
+       "{'Table Retrieval Task': {'spidert-test': TaskResultsDataModel(retrieval_performance=RetrievalPerformanceDataModel(k=5, accuracy=0.0, precision=None, recall=0.0, retrieval_duration_process=0.02657, avg_retrieval_duration_process=1e-05, retrieval_duration_wall_clock=0.02521, avg_retrieval_duration_wall_clock=1e-05), downstream_task_performance=DownstreamTaskPerformanceDataModel(task_name=None, scores=None), embedding_statistics=EmbeddingStatisticsDataModel(embedding_creation_duration_process=0.00034, avg_embedding_creation_duration_process=0.0, embedding_creation_duration_wall_clock=0.00032, avg_embedding_creation_duration_wall_clock=0.0, embedding_size=0.0, avg_embedding_size=0.0))}}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
To see the demo,
- go to the demo folder
- run the `demo_notebook.ipynb`
- I added a dummy retriever, just as a sample for what the retriever could look like 
- the spider config is set to include five tables selected at random. i haven't added a functionality to set seed for random sampling, will do in future.