### PR TITLE
fix: added better embedding tolerance logic for openai embedding

### DIFF
--- a/experiments/retrieval/nih_retrieval_evals.py
+++ b/experiments/retrieval/nih_retrieval_evals.py
@@ -21,7 +21,7 @@ def main():
     top_ks = args.top_ks
     num_nih_tables = args.num_nih_tables
 
-    retriever = initialize_retriever(retriever_name, num_rows, "nih")
+    retriever = initialize_retriever(retriever_name, num_rows, f"nih/{num_nih_tables}")
     gittables_config = DEFAULT_GITTABLES_DATASET_CONFIG.model_copy()
     gittables_config.num_tables = num_nih_tables
     table_retrieval_task = TableRetrievalTask(


### PR DESCRIPTION
Minor updates to openai embeddings
- evaluated on headers only. did not evaluate on including table row contents in the embeddings. if we find these results interesting, we can run the evals with table row contents included in the embeddings
- to mitigate the headers length being longer than the context length of openai embedding models (happens for some gittable tables), implemented chunking & averaging chunk embeddings.