### PR TITLE
Fix/nih evaluation dataset naming

### DIFF
--- a/target_benchmark/evaluators/TARGET.py
+++ b/target_benchmark/evaluators/TARGET.py
@@ -304,7 +304,13 @@ class TARGET:
                     loader, Text2SQLDatasetLoader
                 ), f"data loader for dataset {name} is not a text to sql dataset."
             task.setup_database_dirs(task_dataloaders)
-        return task_dataloaders, nih_dataloaders
+
+        task_dataloaders_updated_name = {}
+        nih_dataloaders_lst = list(nih_dataloaders.values())
+        # update dataset identifier to include id for nih datasets
+        for dataloader in task_dataloaders.values():
+            task_dataloaders_updated_name[construct_dataset_name_for_eval(dataloader, nih_dataloaders_lst)] = dataloader
+        return task_dataloaders_updated_name, nih_dataloaders
 
     def setup_logger(self, persist_log: bool = True, log_file_path: str = None) -> logging.Logger:
         """
@@ -495,8 +501,6 @@ class TARGET:
             nih_dataloaders = list(nih_dataloaders.values())
             # call embed corpus on the retriever to embed/preprocess the tables
             for dataset_name, task_dataloader in task_dataloaders.items():
-                # update embedding name to include id for nih datasets
-                dataset_name = construct_dataset_name_for_eval(task_dataloader, nih_dataloaders)
                 if dataset_name not in loaded_datasets:
                     task_dataloader_with_nih = [task_dataloader] + nih_dataloaders
                     size_of_corpus = self._calculate_corpus_size(task_dataloader_with_nih)

--- a/target_benchmark/evaluators/TARGET.py
+++ b/target_benchmark/evaluators/TARGET.py
@@ -32,7 +32,11 @@ from target_benchmark.dictionary_keys import (
     TABLE_COL_NAME,
     TABLE_ID_COL_NAME,
 )
-from target_benchmark.evaluators.utils import corpus_gen, find_tasks
+from target_benchmark.evaluators.utils import (
+    construct_dataset_name_for_eval,
+    corpus_gen,
+    find_tasks,
+)
 from target_benchmark.retrievers import (
     AbsCustomEmbeddingRetriever,
     AbsRetrieverBase,
@@ -492,7 +496,7 @@ class TARGET:
             # call embed corpus on the retriever to embed/preprocess the tables
             for dataset_name, task_dataloader in task_dataloaders.items():
                 # update embedding name to include id for nih datasets
-                # dataset_name = construct_dataset_name_for_eval(task_dataloader, nih_dataloaders)
+                dataset_name = construct_dataset_name_for_eval(task_dataloader, nih_dataloaders)
                 if dataset_name not in loaded_datasets:
                     task_dataloader_with_nih = [task_dataloader] + nih_dataloaders
                     size_of_corpus = self._calculate_corpus_size(task_dataloader_with_nih)

--- a/target_benchmark/evaluators/TARGET.py
+++ b/target_benchmark/evaluators/TARGET.py
@@ -491,6 +491,8 @@ class TARGET:
             nih_dataloaders = list(nih_dataloaders.values())
             # call embed corpus on the retriever to embed/preprocess the tables
             for dataset_name, task_dataloader in task_dataloaders.items():
+                # update embedding name to include id for nih datasets
+                # dataset_name = construct_dataset_name_for_eval(task_dataloader, nih_dataloaders)
                 if dataset_name not in loaded_datasets:
                     task_dataloader_with_nih = [task_dataloader] + nih_dataloaders
                     size_of_corpus = self._calculate_corpus_size(task_dataloader_with_nih)
@@ -522,6 +524,7 @@ class TARGET:
 
             path_to_retrieval_results = self._create_persistence_file(retrieval_results_file)
             path_to_downstream_results = self._create_persistence_file(downstream_results_file)
+
             # run the task!
             task_result = task.task_run(
                 retriever=retriever,

--- a/target_benchmark/evaluators/utils.py
+++ b/target_benchmark/evaluators/utils.py
@@ -5,7 +5,28 @@ from typing import Dict, List, Type
 
 import target_benchmark.tasks
 from target_benchmark.dataset_loaders.AbsDatasetLoader import AbsDatasetLoader
+from target_benchmark.dataset_loaders.NeedleInHaystackDataLoader import (
+    NeedleInHaystackDataLoader,
+)
 from target_benchmark.tasks.AbsTask import AbsTask
+
+
+def construct_dataset_name_for_eval(non_nih_dataset: AbsDatasetLoader, nih_datasets: List[NeedleInHaystackDataLoader]) -> str:
+    """
+
+    Construct a unique identifier for the corpus with nih datasets added.
+    Uses the name of the NIH datasets and the number of tables included from the NIH datasets.
+
+    """
+
+    dataset_name = non_nih_dataset.dataset_name
+    for nih_dataset in nih_datasets:
+        dataset_name += f"_{nih_dataset.dataset_name}"
+        if nih_dataset.num_tables:
+            dataset_name += f"_{nih_dataset.num_tables}"
+        else:
+            dataset_name += "_all"
+    return dataset_name
 
 
 def corpus_gen(dataloaders: List[AbsDatasetLoader], corpus_format: str, batch_size: int):

--- a/target_benchmark/tasks/AbsTask.py
+++ b/target_benchmark/tasks/AbsTask.py
@@ -183,6 +183,14 @@ class AbsTask(ABC):
         updated_configs.update(dict(configs))
         return updated_configs
 
+    def _validate_dataset_loaders(self, dataset_loaders: Dict[str, AbsDatasetLoader]):
+        for dataset_loader in dataset_loaders.values():
+            if dataset_loader.dataset_name not in self.dataset_config.keys():
+                raise ValueError(
+                    f"Invalid dataset loader: '{dataset_loader.dataset_name}' is not configured for this task. "
+                    f"Ensure that the names match one of the configured datasets: {list(self.  dataset_config.keys())}."
+                )
+
     def task_run(
         self,
         retriever: AbsRetrieverBase,
@@ -208,9 +216,7 @@ class AbsTask(ABC):
         Returns:
             A dictionary with the results of the retrieval task. Maps dataset name to a task result data model object. The task result data model object records both the retrieval performance and the downstream generation results.
         """
-        # assert (
-        #     dataset_loaders.keys() <= self.dataset_config.keys()
-        # ), f"the dataset loaders passed in is not a subset of task's dataset config! \ntask dataset config: {self.dataset_config.keys()}\ndataset loaders passed in: {dataset_loaders.keys()}"
+        self._validate_dataset_loaders(dataset_loaders)
 
         assert isinstance(retriever, CustomEmbRetr) or isinstance(
             retriever, StandardizedEmbRetr

--- a/target_benchmark/tasks/AbsTask.py
+++ b/target_benchmark/tasks/AbsTask.py
@@ -208,9 +208,9 @@ class AbsTask(ABC):
         Returns:
             A dictionary with the results of the retrieval task. Maps dataset name to a task result data model object. The task result data model object records both the retrieval performance and the downstream generation results.
         """
-        assert (
-            dataset_loaders.keys() <= self.dataset_config.keys()
-        ), f"the dataset loaders passed in is not a subset of task's dataset config! \ntask dataset config: {self.dataset_config.keys()}\ndataset loaders passed in: {dataset_loaders.keys()}"
+        # assert (
+        #     dataset_loaders.keys() <= self.dataset_config.keys()
+        # ), f"the dataset loaders passed in is not a subset of task's dataset config! \ntask dataset config: {self.dataset_config.keys()}\ndataset loaders passed in: {dataset_loaders.keys()}"
 
         assert isinstance(retriever, CustomEmbRetr) or isinstance(
             retriever, StandardizedEmbRetr

--- a/target_benchmark/tasks/AbsTask.py
+++ b/target_benchmark/tasks/AbsTask.py
@@ -228,11 +228,7 @@ class AbsTask(ABC):
             total_num_queries = dataset_loader.get_queries_size()
             progress_bar = tqdm(total=total_num_queries, desc=f"Retrieving Tables for {dataset_name}...")
             for query_batch in dataset_loader.get_queries_for_task(batch_size):
-                (
-                    retrieval_results,
-                    process_duration,
-                    wall_clock_duration,
-                ) = self._get_retrieval_results(
+                retrieval_results, process_duration, wall_clock_duration = self._get_retrieval_results(
                     retriever,
                     query_batch,
                     dataset_name,

--- a/target_benchmark/tasks/utils.py
+++ b/target_benchmark/tasks/utils.py
@@ -284,5 +284,5 @@ def validate_dataset_configs(constructed_config: Dict[str, DatasetConfigDataMode
         num_total += 1
     assert num_total != 0, "No datasets configurated!"
     assert num_non_nih != 0, "Cannot have only Needle in Haystack datasets!"
-    assert num_text2sql and num_non_nih >= num_total, "Cannot have T2SQL & NIH!"
+    assert not num_text2sql or (num_text2sql and num_non_nih >= num_total), "Cannot have T2SQL & NIH!"
     return True

--- a/target_benchmark/tasks/utils.py
+++ b/target_benchmark/tasks/utils.py
@@ -16,6 +16,7 @@ from target_benchmark.dataset_loaders.AbsDatasetLoader import AbsDatasetLoader
 from target_benchmark.dataset_loaders.LoadersDataModels import (
     DatasetConfigDataModel,
     NeedleInHaystackDatasetConfigDataModel,
+    Text2SQLDatasetConfigDataModel,
 )
 from target_benchmark.dictionary_keys import DATASET_NAME
 from target_benchmark.generators.GeneratorPrompts import NO_CONTEXT_TABLE_PROMPT
@@ -85,24 +86,16 @@ def iterated_execute_sql(
     iterate_num: int,
     include_ves: bool = False,
 ) -> float:
-    assert (
-        len(predicted_sql_and_db) == 2
-    ), f"malformatted predicted sql db pairs: {predicted_sql_and_db}"
-    assert (
-        len(ground_truth_sql_and_db) == 2
-    ), f"malformatted ground truth sql db pairs: {ground_truth_sql_and_db}"
+    assert len(predicted_sql_and_db) == 2, f"malformatted predicted sql db pairs: {predicted_sql_and_db}"
+    assert len(ground_truth_sql_and_db) == 2, f"malformatted ground truth sql db pairs: {ground_truth_sql_and_db}"
     predicted_sql, predicted_db = predicted_sql_and_db
     ground_truth, ground_truth_db = ground_truth_sql_and_db
     # given a predicted sql, ground truth sql,
     # and the respective db paths of each, get efficiency results.
-    pred_conn = sqlite3.connect(
-        os.path.join(db_root_path, predicted_db, f"{predicted_db}.sqlite")
-    )
+    pred_conn = sqlite3.connect(os.path.join(db_root_path, predicted_db, f"{predicted_db}.sqlite"))
     pred_cursor = pred_conn.cursor()
 
-    gt_conn = sqlite3.connect(
-        os.path.join(db_root_path, ground_truth_db, f"{ground_truth_db}.sqlite")
-    )
+    gt_conn = sqlite3.connect(os.path.join(db_root_path, ground_truth_db, f"{ground_truth_db}.sqlite"))
     gt_cursor = gt_conn.cursor()
 
     diff_list = []
@@ -269,24 +262,27 @@ def evaluate_sql_execution(
     return compute_performance_by_diff(exec_result, difficulties, include_ves)
 
 
-def validate_dataset_configs(
-    constructed_config: Dict[str, DatasetConfigDataModel]
-) -> bool:
+def validate_dataset_configs(constructed_config: Dict[str, DatasetConfigDataModel]) -> bool:
     """
     Validate that the dataset configs are constructured correctly.
     Current rules (more to be added potentially):
     - cannot be empty
     - cannot be only needle in haystack datasets
+    - cannot have NIH with text2sql (not tried but probably NIH datasets inserted into sqlite will not end well.)
     Returns:
         True if dataset configs are correctly constructed.
         Otherwise throw assertion error
     """
     num_non_nih = 0
     num_total = 0
+    num_text2sql = 0
     for dataset_name, config in constructed_config.items():
         if not isinstance(config, NeedleInHaystackDatasetConfigDataModel):
             num_non_nih += 1
+        if isinstance(config, Text2SQLDatasetConfigDataModel):
+            num_text2sql += 1
         num_total += 1
     assert num_total != 0, "No datasets configurated!"
     assert num_non_nih != 0, "Cannot have only Needle in Haystack datasets!"
+    assert num_text2sql and num_non_nih >= num_total, "Cannot have T2SQL & NIH!"
     return True


### PR DESCRIPTION
Fixed dataset naming to disambiguate datasets with different NIH injection sizes
- previously, code does not treat fetaqa vs fetaqa with 10k nih tables differently. both will be named "fetaqa". this causes confusion, as there's no way to tell if a dataset has nih tables included or how many nih tables are included.
- fixed by dynamically updating datasets names with nih tables injected. ensured consistent naming.