### PR TITLE
fix openai api key requirement for retrieval-only experiments

### DIFF
--- a/target_benchmark/tasks/AbsTask.py
+++ b/target_benchmark/tasks/AbsTask.py
@@ -87,7 +87,9 @@ class AbsTask(ABC):
             self.task_name: str = task_name
         self.dataset_config: Dict[str, DatasetConfigDataModel] = self._construct_dataset_config(datasets_config)
 
-        self.task_generator = task_generator if task_generator is not None else DefaultGenerator()
+        self.task_generator = task_generator
+        if task_generator is None and task_name != "Table Retrieval Task":
+            self.task_generator = DefaultGenerator()
         self.total_queries_processed = 0
         self.num_overlap = 0
         self.total_tables = 0


### PR DESCRIPTION
Fixes issue #48 ["OpenAIError on TARGET instantiation"](https://github.com/target-benchmark/target/issues/48)

## Description

Additional check for `task_name` on Task instantiation. Expanded into "if"-clause for better readability.