### PR TITLE
Fix/misalignment in user facing api for standard embedding retriever

### DIFF
--- a/target_benchmark/retrievers/AbsStandardEmbeddingRetriever.py
+++ b/target_benchmark/retrievers/AbsStandardEmbeddingRetriever.py
@@ -48,9 +48,7 @@ class AbsStandardEmbeddingRetriever(AbsRetrieverBase):
                 f"missing key {CLIENT_KEY_NAME} in kwargs. must be included to use standardized embedding retriever."
             )
         client: QdrantClient = kwargs.get(CLIENT_KEY_NAME)
-        for query_id, query_str in zip(
-            queries[QUERY_ID_COL_NAME], queries[QUERY_COL_NAME]
-        ):
+        for query_id, query_str in zip(queries[QUERY_ID_COL_NAME], queries[QUERY_COL_NAME]):
             result = client.search(
                 collection_name=dataset_name,
                 query_vector=self.embed_query(query_str, dataset_name, **kwargs),
@@ -77,7 +75,6 @@ class AbsStandardEmbeddingRetriever(AbsRetrieverBase):
         self,
         query: str,
         dataset_name: str,
-        **kwargs,
     ) -> np.ndarray:
         """
         Given a query, return the query embedding for searching.

--- a/target_benchmark/retrievers/AbsStandardEmbeddingRetriever.py
+++ b/target_benchmark/retrievers/AbsStandardEmbeddingRetriever.py
@@ -51,7 +51,7 @@ class AbsStandardEmbeddingRetriever(AbsRetrieverBase):
         for query_id, query_str in zip(queries[QUERY_ID_COL_NAME], queries[QUERY_COL_NAME]):
             result = client.search(
                 collection_name=dataset_name,
-                query_vector=self.embed_query(query_str, dataset_name, **kwargs),
+                query_vector=self.embed_query(query_str, dataset_name),
                 limit=top_k,
                 with_payload=True,
             )

--- a/target_benchmark/retrievers/naive/DefaultOpenAIEmbeddingRetriever.py
+++ b/target_benchmark/retrievers/naive/DefaultOpenAIEmbeddingRetriever.py
@@ -22,7 +22,6 @@ class OpenAIEmbedder(AbsStandardEmbeddingRetriever):
         self,
         query: str,
         dataset_name: str,
-        **kwargs,
     ) -> np.ndarray:
         emb = self.create_embedding(query)
         return np.array(emb)


### PR DESCRIPTION
Fix issue with misalignment of `AbsStandardEmbeddingRetriever`'s user-facing api and documentation. 

Removed unnecessary `**kwargs` argument to the `embed_query` function. The api should now be aligned with the documentation.

Removed outdated usage of `kwargs` from already implemented retrievers.