### PR TITLE
Feat/row serialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,68 @@ qa_task = QuestionAnsweringTask(task_generator=YourGenerator())
 target_evaluator = TARGET(downstream_tasks=qa_task)
 ```
 Note that here instead of specifying the task by its name, we are passing in a task object instead with the generator set to our created custom generator.
+
+## Using the Evaluation Scripts
+You can run the evaluation scripts in the `experiments` folder to run baselines retrievers included in the TARGET paper on all tasks.
+
+### Command-Line Arguments
+
+- **`--retriever_name`**  
+  **Type:** `str`  
+  **Description:** Name of the retriever. Available options include:
+  - `llamaindex`
+  - `hnsw_openai`
+  - `tfidf_no_title`
+  - `tfidf_with_title`
+  - `bm25_no_title`
+  - `bm25_with_title`
+  - `stella`
+  - `e5`
+  - `row_serial`
+
+- **`--num_rows`**  
+  **Type:** `int`  
+  **Default:** `100`  
+  **Description:** Num rows to include for Dense Table Embedding models
+
+- **`--persist`**  
+  **Action:** `store_true`  
+  **Default:** `False`  
+  **Description:** Whether to persist the data. Defaults to False.
+
+- **`--retrieval_results_dir`**  
+  **Type:** `str`  
+  **Default:** `None`  
+  **Description:** Folder to persist retrieval results.
+
+- **`--downstream_results_dir`**  
+  **Type:** `str`  
+  **Default:** `None`  
+  **Description:** Folder to persist downstream results.
+
+- **`--top_ks`**  
+  **Type:** `str` (later converted to a list of integers)  
+  **Default:** `"1 5 10 25 50"`  
+  **Description:** Space separated list of top ks. for example '1 3 5 10'.
+
+- **`--num_nih_tables`**  
+  **Type:** `int`  
+  **Default:** `None`  
+  **Description:** Number of tables to include from the NIH dataset.
+
+---
+
+### Usage Example
+
+Below is an example command on how to run the script with arguments:
+
+```bash
+python experiments/retrieval_evals.py \
+  --retriever_name stella \
+  --num_rows 150 \
+  --persist \
+  --retrieval_results_dir "./results/retrieval" \
+  --downstream_results_dir "./results/downstream" \
+  --top_ks "1 5 10" \
+  --num_nih_tables 50
+```

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -7,6 +7,7 @@ from target_benchmark.retrievers import (
     HNSWOpenAIEmbeddingRetriever,
     LlamaIndexRetriever,
     OTTQARetriever,
+    RowSerializationRetriever,
     StellaEmbeddingRetriever,
 )
 
@@ -93,6 +94,8 @@ def initialize_retriever(retriever_name: str, num_rows: int = None, out_dir_appe
         return OTTQARetriever(encoding="bm25", withtitle=True)
     elif "stella" in retriever_name:
         return StellaEmbeddingRetriever(num_rows=num_rows)
+    elif "row_serial" in retriever_name:
+        return RowSerializationRetriever()
     else:
         raise ValueError(f"Passed in retriever {retriever_name} not yet supported")
 

--- a/target_benchmark/retrievers/__init__.py
+++ b/target_benchmark/retrievers/__init__.py
@@ -9,5 +9,6 @@ from target_benchmark.retrievers.naive.DefaultOpenAIEmbeddingRetriever import Op
 from target_benchmark.retrievers.ottqa.OTTQARetriever import OTTQARetriever
 from target_benchmark.retrievers.llama_index.LlamaIndexRetriever import LlamaIndexRetriever
 from target_benchmark.retrievers.stella.StellaEmbeddingRetriever import StellaEmbeddingRetriever
+from target_benchmark.retrievers.row_serialization.RowSerializationRetriever import RowSerializationRetriever
 
-__all__ = [AbsCustomEmbeddingRetriever, AbsStandardEmbeddingRetriever, HNSWOpenAIEmbeddingRetriever, NoContextRetriever, OpenAIEmbedder, OTTQARetriever, LlamaIndexRetriever, StellaEmbeddingRetriever]
+__all__ = [AbsCustomEmbeddingRetriever, AbsStandardEmbeddingRetriever, HNSWOpenAIEmbeddingRetriever, NoContextRetriever, OpenAIEmbedder, OTTQARetriever, LlamaIndexRetriever, StellaEmbeddingRetriever, RowSerializationRetriever]

--- a/target_benchmark/retrievers/naive/HNSWOpenAIEmbeddingRetriever.py
+++ b/target_benchmark/retrievers/naive/HNSWOpenAIEmbeddingRetriever.py
@@ -101,7 +101,7 @@ class HNSWOpenAIEmbeddingRetriever(AbsCustomEmbeddingRetriever):
         idx_path, db_table_ids_path = self._construct_persistence_paths(corpus_identifier)
 
         if idx_path.exists() and db_table_ids_path.exists():
-            print("using previously constructed index")
+            print(f"using previously constructed index at: {idx_path}")
             return
 
         embedded_corpus = self._embed_corpus_parallel(corpus)
@@ -133,7 +133,7 @@ class HNSWOpenAIEmbeddingRetriever(AbsCustomEmbeddingRetriever):
     def _process_table(self, db_id: str, table_id: str, table: List[List[str]]) -> Tuple[Tuple[str, str], str]:
         tup_id = (db_id, table_id)
         num_rows_to_include = len(table)
-        if self.num_rows:
+        if self.num_rows is not None:
             num_rows_to_include = self.num_rows
         while num_rows_to_include >= 0:
             table_str = markdown_table_str(table, num_rows=num_rows_to_include)

--- a/target_benchmark/retrievers/row_serialization/RowSerializationRetriever.py
+++ b/target_benchmark/retrievers/row_serialization/RowSerializationRetriever.py
@@ -18,12 +18,14 @@ file_dir = Path(__file__).parent / "data"
 
 
 class RowSerializationRetriever(AbsCustomEmbeddingRetriever):
-    def __init__(self, embeddings_dir: str = str(file_dir)):
+    def __init__(self, embeddings_dir: str = str(file_dir), batch_size=256):
         super().__init__("nested array")
         self.model = SentenceTransformer("dunzhang/stella_en_400M_v5", trust_remote_code=True).cuda()
         self.embeddings_dir = embeddings_dir
+        Path(self.embeddings_dir).mkdir(parents=True, exist_ok=True)
         self.client = QdrantClient(path=self.embeddings_dir)
         self.emb_dims = self.model.get_sentence_embedding_dimension()
+        self.batch_size = batch_size
 
     def retrieve(self, query: str, dataset_name: str, top_k: int, **kwargs) -> List[Tuple]:
         assert self.client.collection_exists(dataset_name)

--- a/target_benchmark/retrievers/row_serialization/RowSerializationRetriever.py
+++ b/target_benchmark/retrievers/row_serialization/RowSerializationRetriever.py
@@ -28,6 +28,14 @@ class RowSerializationRetriever(AbsCustomEmbeddingRetriever):
         self.batch_size = batch_size
 
     def retrieve(self, query: str, dataset_name: str, top_k: int, **kwargs) -> List[Tuple]:
+        # retrieve function will need to ensure that the top k **TABLES** will be retrieved,
+        # not just the top k rows. the general flow is as follows:
+        # - get the number of vectors from the collection
+        # - keep searching until we collect k distinct tables from the rows retrieved.
+        # - add the table id to which the row belongs to the `results_dict`
+        # - to each table id in the dict, the value is the index (`idx`) that it appeared in the research results.
+        # - sort the `results_dict` by the value. since the search results are ordered by similarity,
+        #   we ensure the returned list of table ids is ordered by similarity.
         assert self.client.collection_exists(dataset_name)
         num_points = self.client.count(collection_name=dataset_name, exact=True).count
         results_dict = {}

--- a/target_benchmark/retrievers/row_serialization/RowSerializationRetriever.py
+++ b/target_benchmark/retrievers/row_serialization/RowSerializationRetriever.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+from qdrant_client import QdrantClient, models
+from sentence_transformers import SentenceTransformer
+
+from target_benchmark.dictionary_keys import (
+    DATABASE_ID_COL_NAME,
+    METADATA_DB_ID_KEY_NAME,
+    METADATA_TABLE_ID_KEY_NAME,
+    TABLE_COL_NAME,
+    TABLE_ID_COL_NAME,
+)
+from target_benchmark.retrievers import AbsCustomEmbeddingRetriever
+
+file_dir = Path(__file__).parent / "storage"
+
+
+class RowSerializationRetriever(AbsCustomEmbeddingRetriever):
+    def __init__(self, embeddings_dir: str = str(file_dir)):
+        super().__init__("nested array")
+        self.model = SentenceTransformer("dunzhang/stella_en_400M_v5", trust_remote_code=True).cuda()
+        self.client = QdrantClient(Path(embeddings_dir))
+        self.emb_dims = self.model.get_sentence_embedding_dimension()
+
+    def retrieve(self, query: str, dataset_name: str, top_k: int, **kwargs) -> List[Tuple]:
+        num_points = self.client.count(collection_name=dataset_name, exact=True)
+        results_dict = {}
+        search_limit = top_k
+        idx = 0
+        while len(results_dict) < top_k and search_limit <= num_points:
+            result = self.client.search(
+                collection_name=dataset_name,
+                query_vector=self.embed_query(query, dataset_name),
+                limit=search_limit,
+                with_payload=True,
+            )
+            while len(results_dict) < top_k and idx < len(result):
+                scored_point = result[idx]
+                table_id = (
+                    scored_point.payload[METADATA_DB_ID_KEY_NAME],
+                    scored_point.payload[METADATA_TABLE_ID_KEY_NAME],
+                )
+                if table_id not in results_dict:
+                    results_dict[table_id] = idx
+                idx += 1
+            search_limit *= 2
+        return sorted(results_dict, key=results_dict.get)
+
+    def embed_corpus(self, dataset_name: str, corpus: Iterable[Dict]):
+        if self.client.collection_exists(dataset_name):
+            return
+        self.client.create_collection(
+            collection_name=dataset_name,
+            vectors_config=models.VectorParams(size=self.emb_dims, distance=models.Distance.COSINE),
+        )
+        metadata = []
+        vectors = []
+        for entry in corpus:
+            entry = {key: value[0] for key, value in entry.items()}
+            # serialize table into a list of strings
+            serialized_table = self._serialize_table(entry[TABLE_COL_NAME])
+            # encode the table
+            table_embedding = self.model.encode(serialized_table)
+
+            # check how many duplicate metadata entries are needed
+            num_metadata = 1
+            if table_embedding.ndim == 1:
+                table_embedding = np.expand_dims(table_embedding, axis=0)
+            else:
+                num_metadata = table_embedding.shape[0]
+
+            # shape of table_embedding: <num_vectors x dim of vector>
+            vectors.append(table_embedding)
+            # for all vectors corresponding to the same table,
+            # you need the same metadata entry
+            metadata.extend(
+                [
+                    {
+                        METADATA_TABLE_ID_KEY_NAME: entry[TABLE_ID_COL_NAME],
+                        METADATA_DB_ID_KEY_NAME: entry[DATABASE_ID_COL_NAME],
+                    }
+                ]
+                * num_metadata
+            )
+
+        vectors = np.concatenate(vectors, axis=0)
+        assert vectors.shape[0] == len(
+            metadata
+        ), f"Mismatch between vectors shape and the metadata entries! Shape: {vectors.shape[0]}, Metadata entries: {len(metadata)}"
+        self.client.upload_collection(
+            dataset_name,
+            vectors=vectors,
+            payload=metadata,
+        )
+
+    def _serialize_table(self, corpus_entry: Dict) -> List[str]:
+        table = corpus_entry[TABLE_COL_NAME]  # get the table as a nested array
+        serialized_rows = []  # keep an array, each element will be a serialized row
+        headers = table[0]  # grab table column names
+        for row in corpus_entry[TABLE_COL_NAME][1:]:
+            assert len(headers) == len(row)
+            row_str = ""  # build the table string
+            for col_name, cell_value in zip(headers, row):
+                # match each column name to the cell value.
+                row_str += f"{col_name} is {cell_value}, "
+            serialized_rows.append(row_str)
+        return serialized_rows

--- a/tests/retrievers/row_serializer_test.py
+++ b/tests/retrievers/row_serializer_test.py
@@ -1,5 +1,6 @@
 import shutil
 import unittest
+from pathlib import Path
 
 from target_benchmark.dataset_loaders import HFDatasetLoader
 from target_benchmark.dataset_loaders.TargetDatasetConfig import (
@@ -10,7 +11,7 @@ from target_benchmark.retrievers import RowSerializationRetriever
 
 class TestRowSerializationEmbeddingRetriever(unittest.TestCase):
     def setUp(self):
-        self.retriever = RowSerializationRetriever()
+        self.retriever = RowSerializationRetriever(str(Path(__file__).parent / "data"))
         self.dataloader = HFDatasetLoader(**DEFAULT_DUMMY_DATASET_CONFIG.model_dump())
         self.dataloader.load()
 

--- a/tests/retrievers/row_serializer_test.py
+++ b/tests/retrievers/row_serializer_test.py
@@ -1,0 +1,42 @@
+import shutil
+import unittest
+
+from target_benchmark.dataset_loaders import HFDatasetLoader
+from target_benchmark.dataset_loaders.TargetDatasetConfig import (
+    DEFAULT_DUMMY_DATASET_CONFIG,
+)
+from target_benchmark.retrievers import RowSerializationRetriever
+
+
+class TestRowSerializationEmbeddingRetriever(unittest.TestCase):
+    def setUp(self):
+        self.retriever = RowSerializationRetriever()
+        self.dataloader = HFDatasetLoader(**DEFAULT_DUMMY_DATASET_CONFIG.model_dump())
+        self.dataloader.load()
+
+    def test_basic_embed(self):
+        self.retriever.embed_corpus("fetaqa", self.dataloader.convert_corpus_table_to())
+
+        client = self.retriever.client
+        self.assertEqual(client.count("fetaqa", exact=True).count, 11)
+
+    def test_retrieve(self):
+        self.retriever.embed_corpus("fetaqa", self.dataloader.convert_corpus_table_to())
+
+        query = "who is the manager?"
+        retrieval = self.retriever.retrieve(query, "fetaqa", 5)
+        counts = {}
+        for retrieved in retrieval:
+            if retrieved not in counts:
+                counts[retrieved] = 0
+            counts[retrieved] += 1
+        self.assertEqual(len(counts), 5)
+        for key in counts:
+            self.assertEqual(counts[key], 1)
+
+    def tearDown(self):
+        shutil.rmtree(self.retriever.embeddings_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added row-serialize retriever for the feb 15th resubmission

Branch for the Dense Row-level Embedding approach included in the updated resubmission.

- In constrast to the Dense Table Embedding approaches (where the entire / truncated part of a table is serialized into a single string for embedding), this approach serializes each row of a table and creates a separate embedding for the row. 
- The embeddings are persisted to local instance of qdrant db to prevent repeated embedding across eval runs.
- Added a unittest to test functionality.

Misc: 
- fixed error in Openai Embedding retriever that was causing header_only & rows_included variations of the Dense Table Embedding evals to both include table rows.