### PR TITLE
Feat/e5 embedding retriever

### DIFF
--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 from target_benchmark.evaluators import TARGET
 from target_benchmark.retrievers import (
+    E5EmbeddingRetriever,
     HNSWOpenAIEmbeddingRetriever,
     LlamaIndexRetriever,
     OTTQARetriever,
@@ -93,6 +94,8 @@ def initialize_retriever(retriever_name: str, num_rows: int = None, out_dir_appe
         return OTTQARetriever(encoding="bm25", withtitle=True)
     elif "stella" in retriever_name:
         return StellaEmbeddingRetriever(num_rows=num_rows)
+    elif "e5" in retriever_name:
+        return E5EmbeddingRetriever(num_rows=num_rows)
     else:
         raise ValueError(f"Passed in retriever {retriever_name} not yet supported")
 

--- a/target_benchmark/retrievers/__init__.py
+++ b/target_benchmark/retrievers/__init__.py
@@ -9,5 +9,6 @@ from target_benchmark.retrievers.naive.DefaultOpenAIEmbeddingRetriever import Op
 from target_benchmark.retrievers.ottqa.OTTQARetriever import OTTQARetriever
 from target_benchmark.retrievers.llama_index.LlamaIndexRetriever import LlamaIndexRetriever
 from target_benchmark.retrievers.stella.StellaEmbeddingRetriever import StellaEmbeddingRetriever
+from target_benchmark.retrievers.e5.E5EmbeddingRetriever import E5EmbeddingRetriever
 
-__all__ = [AbsCustomEmbeddingRetriever, AbsStandardEmbeddingRetriever, HNSWOpenAIEmbeddingRetriever, NoContextRetriever, OpenAIEmbedder, OTTQARetriever, LlamaIndexRetriever, StellaEmbeddingRetriever]
+__all__ = [AbsCustomEmbeddingRetriever, AbsStandardEmbeddingRetriever, HNSWOpenAIEmbeddingRetriever, NoContextRetriever, OpenAIEmbedder, OTTQARetriever, LlamaIndexRetriever, StellaEmbeddingRetriever, E5EmbeddingRetriever]

--- a/target_benchmark/retrievers/e5/E5EmbeddingRetriever.py
+++ b/target_benchmark/retrievers/e5/E5EmbeddingRetriever.py
@@ -1,0 +1,35 @@
+from typing import Dict, Union
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+from target_benchmark.dictionary_keys import TABLE_COL_NAME
+from target_benchmark.retrievers import AbsStandardEmbeddingRetriever
+from target_benchmark.retrievers.utils import markdown_table_str
+
+# high performing lightweight embedding model from NovaSearch
+# https://huggingface.co/NovaSearch/stella_en_400M_v5
+
+
+class E5EmbeddingRetriever(AbsStandardEmbeddingRetriever):
+    def __init__(
+        self,
+        num_rows: Union[int, None] = None,
+    ):
+        super().__init__("nested array")
+        self.num_rows = num_rows
+        self.model = SentenceTransformer("intfloat/multilingual-e5-large-instruct", trust_remote_code=True).cuda()
+
+    def embed_query(self, query: str, dataset_name: str) -> np.ndarray:
+        return self.model.encode(query, convert_to_tensor=True, normalize_embeddings=True)
+
+    def embed_corpus(self, dataset_name: str, corpus_entry: Dict) -> np.ndarray:
+        table = corpus_entry[TABLE_COL_NAME]
+        num_rows_to_include = len(table) - 1
+        if self.num_rows is not None:
+            num_rows_to_include = self.num_rows
+        table_str = markdown_table_str(table, num_rows=num_rows_to_include)
+
+        if self.num_rows and num_rows_to_include != self.num_rows:
+            print(f"truncated input due to context length constraints, included {num_rows_to_include} rows")
+        return self.model.encode(table_str, convert_to_tensor=True, normalize_embeddings=True)

--- a/target_benchmark/retrievers/e5/E5EmbeddingRetriever.py
+++ b/target_benchmark/retrievers/e5/E5EmbeddingRetriever.py
@@ -21,7 +21,7 @@ class E5EmbeddingRetriever(AbsStandardEmbeddingRetriever):
         self.model = SentenceTransformer("intfloat/multilingual-e5-large-instruct", trust_remote_code=True).cuda()
 
     def embed_query(self, query: str, dataset_name: str) -> np.ndarray:
-        return self.model.encode(query, convert_to_tensor=True, normalize_embeddings=True)
+        return self.model.encode(query, convert_to_tensor=True, normalize_embeddings=True).cpu().numpy()
 
     def embed_corpus(self, dataset_name: str, corpus_entry: Dict) -> np.ndarray:
         table = corpus_entry[TABLE_COL_NAME]
@@ -32,4 +32,4 @@ class E5EmbeddingRetriever(AbsStandardEmbeddingRetriever):
 
         if self.num_rows and num_rows_to_include != self.num_rows:
             print(f"truncated input due to context length constraints, included {num_rows_to_include} rows")
-        return self.model.encode(table_str, convert_to_tensor=True, normalize_embeddings=True)
+        return self.model.encode(table_str, convert_to_tensor=True, normalize_embeddings=True).cpu().numpy()


### PR DESCRIPTION
Added E5 as an addtional model for Dense Table Embedding approach

- e5 scored quite high on the MTEB leaderboard, and I decided to include it as a part of the comparison between e5, openai, vs stella models for dense table embedding.
- the composition of the retriever class is quite similar to stella. in future refinements we plan to create a class for all sentence_transformer based embedding models.