### PR TITLE
feat: add Murre Retriever for multi-hop retrieval

### DIFF
--- a/experiments/run_murre.py
+++ b/experiments/run_murre.py
@@ -32,7 +32,7 @@ class RetrieverEval:
         self.target.logger.info(f"starting {self.retriever_name}")
         start = time.time()
         res = self.target.run(
-            self.retriever, split="validation", top_k=top_k, batch_size=100, debug=False
+            self.retriever, split="validation", top_k=top_k, batch_size=1, debug=False, max_samples=5
         )
         eval_time = time.time() - start
 
@@ -49,7 +49,7 @@ class RetrieverEval:
         res_dict = {}
         for task_name, task_dict in res.items():
             for dataset_name, dataset_dict in task_dict.items():
-                res_dict["performance"] = dataset_dict.model_dump()
+                res_dict["performance"] = dataset_dict
                 res_dict["eval_time"] = eval_time
 
                 filename = f"eval_{task_name}_{dataset_name}{num_rows_appendix}{beam_size_appendix}{max_hops_appendix}{rewriting_appendix}_{self.result_appendix}.json"
@@ -59,132 +59,49 @@ class RetrieverEval:
 
 
 if __name__ == "__main__":
-    tasks_list = ["Table Question Answering Task", "Fact Verification Task"]
-
-    if RUN_LOCAL_MODELS:
-        print("Running Local Model Configurations")
-        
-        model_name = "qwen3-embedding-0.6b"
-        out_dir = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), f"retrieval_files/murre/{model_name}"
-        )
-        
-        for use_rewriting in [False, True]:
-            for beam_size in [1, 3, 5]:
-                for max_hops in [1, 2, 3]:
-                    for num_rows in [0, 2]:
-                        print(f"Model: Qwen/Qwen3-Embedding-0.6B")
-                        print(f"Embedding Type: sentence-transformers")
-                        print(f"Use Rewriting: {use_rewriting}")
-                        print(f"Beam Size: {beam_size}")
-                        print(f"Max Hops: {max_hops}")
-                        print(f"Num Rows: {num_rows}")
-                        
-                        try:
-                            murre_retriever = MurreRetriever(
-                                model="Qwen/Qwen3-Embedding-0.6B",
-                                embedding_type="sentence-transformers",
-                                use_rewriting=use_rewriting,
-                                beam_size=beam_size,
-                                max_hops=max_hops,
-                                rewriter_model="gpt-4o-mini"
-                            )
-                            murre_retriever.num_rows = num_rows
-                            
-                            RetrieverEval(
-                                retriever_name="MURRE",
-                                out_dir=out_dir,
-                                retriever=murre_retriever,
-                                tasks_list=tasks_list,
-                                result_appendix=f"qwen3_0.6b_beamsize_{beam_size}_maxhops_{max_hops}_rewriting_{use_rewriting}_numrows_{num_rows}",
-                            ).run_eval()
-                            
-                        except Exception as e:
-                            print(f"Error: {e}")
-                            continue
-    else:
-        print("RUN_LOCAL_MODELS = False")
+    tasks_list = [("Table Question Answering Task", "ottqa")]
 
     if RUN_OPENAI_ONLY:
         print("Running OpenAI Config")
         
-        openai_model_name = "openai-text-embedding-3-small"
+        openai_model_name = "openai-text-embedding-3-large"
         openai_out_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), f"retrieval_files/murre/{openai_model_name}"
         )
         
         for beam_size in [1, 3]:
             for max_hops in [1, 2]:
-                for use_rewriting in [False, True]:
-                    print(f"Model: text-embedding-3-small")
-                    print(f"Embedding Type: openai")
-                    print(f"Use Rewriting: {use_rewriting}")
-                    print(f"Beam Size: {beam_size}")
-                    print(f"Max Hops: {max_hops}")
+                use_rewriting = False
+                model_name = "text-embedding-3-large"
+                print(f"Model: {model_name}")
+                print(f"Embedding Type: openai")
+                print(f"Use Rewriting: {use_rewriting}")
+                print(f"Beam Size: {beam_size}")
+                print(f"Max Hops: {max_hops}")
+                
+                try:
+                    murre_openai = MurreRetriever(
+                        model=model_name,
+                        embedding_type="openai",
+                        use_rewriting=use_rewriting,
+                        beam_size=beam_size,
+                        max_hops=max_hops,
+                        rewriter_model="gpt-4o-mini"
+                    )
+                    murre_openai.num_rows = 2
                     
-                    try:
-                        murre_openai = MurreRetriever(
-                            model="text-embedding-3-small",
-                            embedding_type="openai",
-                            use_rewriting=use_rewriting,
-                            beam_size=beam_size,
-                            max_hops=max_hops,
-                            rewriter_model="gpt-4o-mini"
-                        )
-                        murre_openai.num_rows = 2
-                        
-                        RetrieverEval(
-                            retriever_name="MURRE",
-                            out_dir=openai_out_dir,
-                            retriever=murre_openai,
-                            tasks_list=tasks_list,
-                            result_appendix=f"openai_baseline_beamsize_{beam_size}_maxhops_{max_hops}_rewriting_{use_rewriting}",
-                        ).run_eval()
-                        
-                    except Exception as e:
-                        print(f"Error: {e}")
-                        continue
+                    RetrieverEval(
+                        retriever_name="MURRE",
+                        out_dir=openai_out_dir,
+                        retriever=murre_openai,
+                        tasks_list=tasks_list,
+                        result_appendix=f"ottqa_beamsize_{beam_size}_maxhops_{max_hops}_rewriting_{use_rewriting}",
+                    ).run_eval()
+                    
+                except Exception as e:
+                    print(f"Error: {e}")
+                    continue
     else:
         print("RUN_OPENAI_ONLY = False")
-
-    # Custom embedding models 
-    if RUN_LOCAL_MODELS:
-        print("Running Custom Embedding")
-        
-        try:
-            custom_models = [
-                "all-MiniLM-L6-v2",
-                "all-mpnet-base-v2"
-            ]
-            
-            for custom_model in custom_models:
-                custom_out_dir = os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)), f"retrieval_files/murre/{custom_model.replace('/', '_')}"
-                )
-                
-                print(f"{custom_model}")
-                
-                murre_custom = MurreRetriever(
-                    model=custom_model,
-                    embedding_type="sentence-transformers",
-                    use_rewriting=False,
-                    beam_size=3,
-                    max_hops=2
-                )
-                murre_custom.num_rows = 2
-                
-                RetrieverEval(
-                    retriever_name="MURRE",
-                    out_dir=custom_out_dir,
-                    retriever=murre_custom,
-                    tasks_list=tasks_list,
-                    result_appendix=f"custom_{custom_model.replace('/', '_')}_comparison",
-                ).run_eval()
-                
-                
-        except Exception as e:
-            print(f"Error: {e}")
-    else:
-        print("RUN_LOCAL_MODELS = False")
 
     print("Results in: experiments/retrieval_files/murre/")

--- a/experiments/run_murre.py
+++ b/experiments/run_murre.py
@@ -1,0 +1,190 @@
+import json
+import os
+import time
+
+from target_benchmark.evaluators.TARGET import TARGET
+from target_benchmark.retrievers.murre.MurreRetriever import MurreRetriever
+
+RUN_LOCAL_MODELS = False
+RUN_OPENAI_ONLY = True
+
+class RetrieverEval:
+    def __init__(
+        self,
+        retriever_name: str,
+        retriever,
+        tasks_list: list,
+        out_dir: str,
+        result_appendix: str = None,
+    ):
+        self.retriever_name = retriever_name
+        self.result_appendix = result_appendix
+
+        self.out_dir = out_dir
+        if not os.path.exists(self.out_dir):
+            os.makedirs(self.out_dir, exist_ok=True)
+
+        self.retriever = retriever
+
+        self.target = TARGET(tasks_list)
+
+    def run_eval(self, top_k=10):
+        self.target.logger.info(f"starting {self.retriever_name}")
+        start = time.time()
+        res = self.target.run(
+            self.retriever, split="validation", top_k=top_k, batch_size=100, debug=False
+        )
+        eval_time = time.time() - start
+
+        beam_size_appendix = f"_beamsize_{self.retriever.beam_size}"
+        max_hops_appendix = f"_maxhops_{self.retriever.max_hops}"
+        rewriting_appendix = f"_rewriting_{self.retriever.use_rewriting}"
+        
+        if hasattr(self.retriever, 'num_rows'):
+            num_rows_appendix = f"_numrows_{self.retriever.num_rows}"
+        else:
+            self.retriever.num_rows = 0
+            num_rows_appendix = "_numrows_0"
+
+        res_dict = {}
+        for task_name, task_dict in res.items():
+            for dataset_name, dataset_dict in task_dict.items():
+                res_dict["performance"] = dataset_dict.model_dump()
+                res_dict["eval_time"] = eval_time
+
+                filename = f"eval_{task_name}_{dataset_name}{num_rows_appendix}{beam_size_appendix}{max_hops_appendix}{rewriting_appendix}_{self.result_appendix}.json"
+                
+                with open(os.path.join(self.out_dir, filename), "w") as f:
+                    json.dump(res_dict, f)
+
+
+if __name__ == "__main__":
+    tasks_list = ["Table Question Answering Task", "Fact Verification Task"]
+
+    if RUN_LOCAL_MODELS:
+        print("Running Local Model Configurations")
+        
+        model_name = "qwen3-embedding-0.6b"
+        out_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), f"retrieval_files/murre/{model_name}"
+        )
+        
+        for use_rewriting in [False, True]:
+            for beam_size in [1, 3, 5]:
+                for max_hops in [1, 2, 3]:
+                    for num_rows in [0, 2]:
+                        print(f"Model: Qwen/Qwen3-Embedding-0.6B")
+                        print(f"Embedding Type: sentence-transformers")
+                        print(f"Use Rewriting: {use_rewriting}")
+                        print(f"Beam Size: {beam_size}")
+                        print(f"Max Hops: {max_hops}")
+                        print(f"Num Rows: {num_rows}")
+                        
+                        try:
+                            murre_retriever = MurreRetriever(
+                                model="Qwen/Qwen3-Embedding-0.6B",
+                                embedding_type="sentence-transformers",
+                                use_rewriting=use_rewriting,
+                                beam_size=beam_size,
+                                max_hops=max_hops,
+                                rewriter_model="gpt-4o-mini"
+                            )
+                            murre_retriever.num_rows = num_rows
+                            
+                            RetrieverEval(
+                                retriever_name="MURRE",
+                                out_dir=out_dir,
+                                retriever=murre_retriever,
+                                tasks_list=tasks_list,
+                                result_appendix=f"qwen3_0.6b_beamsize_{beam_size}_maxhops_{max_hops}_rewriting_{use_rewriting}_numrows_{num_rows}",
+                            ).run_eval()
+                            
+                        except Exception as e:
+                            print(f"Error: {e}")
+                            continue
+    else:
+        print("RUN_LOCAL_MODELS = False")
+
+    if RUN_OPENAI_ONLY:
+        print("Running OpenAI Config")
+        
+        openai_model_name = "openai-text-embedding-3-small"
+        openai_out_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), f"retrieval_files/murre/{openai_model_name}"
+        )
+        
+        for beam_size in [1, 3]:
+            for max_hops in [1, 2]:
+                for use_rewriting in [False, True]:
+                    print(f"Model: text-embedding-3-small")
+                    print(f"Embedding Type: openai")
+                    print(f"Use Rewriting: {use_rewriting}")
+                    print(f"Beam Size: {beam_size}")
+                    print(f"Max Hops: {max_hops}")
+                    
+                    try:
+                        murre_openai = MurreRetriever(
+                            model="text-embedding-3-small",
+                            embedding_type="openai",
+                            use_rewriting=use_rewriting,
+                            beam_size=beam_size,
+                            max_hops=max_hops,
+                            rewriter_model="gpt-4o-mini"
+                        )
+                        murre_openai.num_rows = 2
+                        
+                        RetrieverEval(
+                            retriever_name="MURRE",
+                            out_dir=openai_out_dir,
+                            retriever=murre_openai,
+                            tasks_list=tasks_list,
+                            result_appendix=f"openai_baseline_beamsize_{beam_size}_maxhops_{max_hops}_rewriting_{use_rewriting}",
+                        ).run_eval()
+                        
+                    except Exception as e:
+                        print(f"Error: {e}")
+                        continue
+    else:
+        print("RUN_OPENAI_ONLY = False")
+
+    # Custom embedding models 
+    if RUN_LOCAL_MODELS:
+        print("Running Custom Embedding")
+        
+        try:
+            custom_models = [
+                "all-MiniLM-L6-v2",
+                "all-mpnet-base-v2"
+            ]
+            
+            for custom_model in custom_models:
+                custom_out_dir = os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), f"retrieval_files/murre/{custom_model.replace('/', '_')}"
+                )
+                
+                print(f"{custom_model}")
+                
+                murre_custom = MurreRetriever(
+                    model=custom_model,
+                    embedding_type="sentence-transformers",
+                    use_rewriting=False,
+                    beam_size=3,
+                    max_hops=2
+                )
+                murre_custom.num_rows = 2
+                
+                RetrieverEval(
+                    retriever_name="MURRE",
+                    out_dir=custom_out_dir,
+                    retriever=murre_custom,
+                    tasks_list=tasks_list,
+                    result_appendix=f"custom_{custom_model.replace('/', '_')}_comparison",
+                ).run_eval()
+                
+                
+        except Exception as e:
+            print(f"Error: {e}")
+    else:
+        print("RUN_LOCAL_MODELS = False")
+
+    print("Results in: experiments/retrieval_files/murre/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ scikit-learn        = "^1.3.0"
 scipy               = "^1.13.0"
 transformers        = "^4.41.2"
 tqdm                = "^4.65.0"
+torch               = "^2.0.0"
+sentence-transformers = "^3.0.0"
 
 llama-index = { version = "^0.10.58", optional = true }
 nltk        = { version = "^3.8.1", optional = true }
@@ -59,6 +61,7 @@ spacy       = { version = "^3.7.4", optional = true }
 [tool.poetry.extras]
 llamaindex_retriever = ["llama-index"]
 ottqa_retriever      = ["nltk", "pexpect", "spacy"]
+murre_retriever      = ["torch", "sentence-transformers"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/target_benchmark/retrievers/__init__.py
+++ b/target_benchmark/retrievers/__init__.py
@@ -10,6 +10,7 @@ from target_benchmark.retrievers.ottqa.OTTQARetriever import OTTQARetriever
 from target_benchmark.retrievers.llama_index.LlamaIndexRetriever import LlamaIndexRetriever
 from target_benchmark.retrievers.row_serialization.RowSerializationRetriever import RowSerializationRetriever
 from target_benchmark.retrievers.sentence_transformers.sentence_transformers_retriever import SentenceTransformersRetriever, StellaEmbeddingRetriever
+from target_benchmark.retrievers.murre.MurreRetriever import MurreRetriever
 
-__all__ = [AbsCustomEmbeddingRetriever, AbsStandardEmbeddingRetriever, RowSerializationRetriever, HNSWOpenAIEmbeddingRetriever, NoContextRetriever, OpenAIEmbedder, OTTQARetriever, LlamaIndexRetriever, StellaEmbeddingRetriever, SentenceTransformersRetriever]
+__all__ = [AbsCustomEmbeddingRetriever, AbsStandardEmbeddingRetriever, RowSerializationRetriever, HNSWOpenAIEmbeddingRetriever, NoContextRetriever, OpenAIEmbedder, OTTQARetriever, LlamaIndexRetriever, StellaEmbeddingRetriever, SentenceTransformersRetriever, MurreRetriever]
 

--- a/target_benchmark/retrievers/murre/MurreRetriever.py
+++ b/target_benchmark/retrievers/murre/MurreRetriever.py
@@ -1,0 +1,412 @@
+import json
+import os
+import numpy as np
+import torch
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple, Any, Optional
+from scipy.spatial.distance import cosine
+from dataclasses import dataclass
+from transformers import AutoModel, AutoTokenizer
+
+try:
+    from langchain_openai import OpenAIEmbeddings, ChatOpenAI
+except ImportError:
+    OpenAIEmbeddings = None
+    ChatOpenAI = None
+
+from target_benchmark.retrievers import AbsCustomEmbeddingRetriever
+
+cur_dir_path = Path(__file__).parent.resolve()
+data_path = cur_dir_path / "data/"
+
+
+@dataclass
+class BeamState:
+    # single beam state
+    retrieved_tables: List[int]
+    current_query: str
+    score: float
+    hop: int
+    
+    def __post_init__(self):
+        self.retrieved_tables = list(self.retrieved_tables) if self.retrieved_tables else []
+
+
+class MurreRetriever(AbsCustomEmbeddingRetriever):
+    def __init__(self, 
+                 model: str = "text-embedding-3-small",
+                 embedding_type: str = "openai",
+                 use_rewriting: bool = False,
+                 beam_size: int = 3,
+                 max_hops: int = 2,
+                 rewriter_model: str = "gpt-4o-mini"):
+        """
+        Initialize MurreRetriever
+
+        Args:
+            model: Embedding model name
+            embedding_type: "openai" or "custom"
+            use_rewriting: Use query rewriting
+            beam_size: Number of beams
+            max_hops: Maximum number of hops
+            rewriter_model: LLM for query rewriting
+        """
+        super().__init__(expected_corpus_format="nested array")
+        
+        self.model = model
+        self.embedding_type = embedding_type
+        self.use_rewriting = use_rewriting
+        self.beam_size = beam_size
+        self.max_hops = max_hops
+        self.rewriter_model = rewriter_model
+        self.embedding_client = None
+        self.rewriter_client = None
+        self.tokenizer = None
+        self.embedding_model = None
+        self.corpus_embeddings = {}
+
+    def retrieve(self, query: str, dataset_name: str, top_k: int, **kwargs) -> List[Tuple[str, str]]:
+        """
+        Retrieve relevant tables using multi-hop beam search
+        
+        Args:
+            query: User query
+            dataset_name: Name of the dataset
+            top_k: Number of tables
+            
+        Returns:
+            List of (database_id, table_id) tuples
+        """
+        if dataset_name not in self.corpus_embeddings:
+            dataset_persistence_path = data_path / dataset_name
+            if not dataset_persistence_path.exists():
+                raise ValueError(f"Corpus for dataset '{dataset_name}' has not been embedded! Run embed_corpus first.")
+            self._load_embeddings(dataset_name)
+        
+        try:
+            if self.beam_size > 1:
+                return self._beam_search_retrieval(query, dataset_name, top_k)
+            else:
+                return self._single_hop_retrieval(query, dataset_name, top_k)
+        except Exception as e:
+            print(f"Error during MURRE retrieval: {e}")
+            return []
+
+    def embed_corpus(self, dataset_name: str, corpus: Iterable[Dict[str, Any]]) -> None:
+        self._ensure_embedding_client()
+        
+        dataset_persistence_path = data_path / dataset_name
+        dataset_persistence_path.mkdir(parents=True, exist_ok=True)
+        
+        all_table_texts = []
+        all_table_ids = []
+        
+        for batch_dict in corpus:
+            batch_db_ids = batch_dict.get("database_id", [])
+            batch_table_names = batch_dict.get("table_id", [])
+            batch_table_contents = batch_dict.get("table", [])
+
+            if not (len(batch_db_ids) == len(batch_table_names) == len(batch_table_contents)):
+                print(f"Warning: Mismatch in lengths of batch lists for dataset {dataset_name}. Skipping batch.")
+                continue
+
+            for i in range(len(batch_db_ids)):
+                db_id = str(batch_db_ids[i])
+                table_name = str(batch_table_names[i])
+                table_content = batch_table_contents[i]
+
+                if table_content is None:
+                    print(f"Warning: Missing 'table' content for {db_id}.{table_name} in dataset {dataset_name}. Skipping.")
+                    continue
+                
+                table_str = self._convert_table_to_string(table_content)
+                all_table_texts.append(table_str)
+                all_table_ids.append((db_id, table_name))
+
+        if not all_table_texts:
+            print(f"Warning: No tables found or processed for dataset {dataset_name}.")
+            return
+
+        all_embeddings = self._get_embeddings_batch(all_table_texts, is_query=False)
+        
+        embedding_data = {
+            "ids": all_table_ids,
+            "embeddings": all_embeddings,
+            "table_strings": all_table_texts,
+            "config": {
+                "model": self.model,
+                "embedding_type": self.embedding_type
+            }
+        }
+        
+        embeddings_path = dataset_persistence_path / "embeddings.json"
+        with open(embeddings_path, 'w') as f:
+            json.dump(embedding_data, f)
+        
+        self.corpus_embeddings[dataset_name] = embedding_data
+        
+
+    def _load_embeddings(self, dataset_name: str) -> None:
+        dataset_persistence_path = data_path / dataset_name
+        embeddings_path = dataset_persistence_path / "embeddings.json"
+        
+        if not embeddings_path.exists():
+            raise ValueError(f"No embeddings file found for dataset '{dataset_name}'! Run embed_corpus first.")
+        
+        with open(embeddings_path, 'r') as f:
+            self.corpus_embeddings[dataset_name] = json.load(f)
+
+    def _ensure_embedding_client(self) -> None:
+        if self.embedding_client is not None:
+            return
+            
+        if self.embedding_type == "openai":
+            self._init_openai_embeddings()
+        else:
+            self._init_custom_embeddings()
+
+    def _ensure_rewriter_client(self) -> None:
+        if not self.use_rewriting or self.rewriter_client is not None:
+            return
+            
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OpenAI API key not found! Please set OPENAI_API_KEY environment variable.")
+        
+        self.rewriter_client = ChatOpenAI(
+            model=self.rewriter_model,
+            openai_api_key=api_key,
+            temperature=0.1,
+            max_tokens=150
+        )
+
+    def _init_openai_embeddings(self) -> None:
+        """Initialize OpenAI embedding client"""
+        
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OpenAI API key not found! Please set OPENAI_API_KEY environment variable.")
+        
+        self.embedding_client = OpenAIEmbeddings(
+            model=self.model,
+            openai_api_key=api_key
+        )
+
+    def _init_custom_embeddings(self) -> None:
+        """Initialize custom embedding model"""
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model)
+            self.embedding_model = AutoModel.from_pretrained(self.model)
+            self.embedding_model.eval()
+            
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            self.embedding_model.to(self.device)
+            
+            # handle SGPT models
+            self.use_specb = "sgpt" in self.model.lower()
+            if self.use_specb:
+                self.SPECB_QUE_BOS = self.tokenizer.encode("[", add_special_tokens=False)[0]
+                self.SPECB_QUE_EOS = self.tokenizer.encode("]", add_special_tokens=False)[0]
+                self.SPECB_DOC_BOS = self.tokenizer.encode("{", add_special_tokens=False)[0]
+                self.SPECB_DOC_EOS = self.tokenizer.encode("}", add_special_tokens=False)[0]
+                
+        except Exception as e:
+            raise ValueError(f"Failed to load custom embedding model: {e}")
+
+    def _get_embeddings_batch(self, texts: List[str], is_query: bool = True) -> List[List[float]]:
+        """Get batch embeddings using configured client"""
+        if self.embedding_type == "openai":
+            if is_query:
+                return [self.embedding_client.embed_query(text) for text in texts]
+            else:
+                return self.embedding_client.embed_documents(texts)
+        else:
+            return self._get_custom_embeddings_batch(texts, is_query)
+
+    def _get_custom_embeddings_batch(self, texts: List[str], is_query: bool) -> List[List[float]]:
+        """Get batch embeddings using custom model"""
+        try:
+            if self.use_specb:
+                tokens = self._tokenize_with_specb(texts, is_query)
+            else:
+                tokens = self.tokenizer(texts, padding=True, truncation=True, 
+                                      return_tensors="pt", max_length=512).to(self.device)
+            
+            with torch.no_grad():
+                outputs = self.embedding_model(**tokens)
+                embeddings = outputs.last_hidden_state.mean(dim=1)
+            
+            return [emb.cpu().numpy().tolist() for emb in embeddings]
+        except Exception as e:
+            print(f"Error getting custom embeddings: {e}")
+            return [[] for _ in texts]
+
+    def _tokenize_with_specb(self, texts: List[str], is_query: bool) -> Dict[str, torch.Tensor]:
+        """Tokenize with SPECB tokens for SGPT models"""
+        batch_tokens = self.tokenizer(texts, padding=False, truncation=True, max_length=512)
+        
+        for seq, att in zip(batch_tokens["input_ids"], batch_tokens["attention_mask"]):
+            if is_query:
+                seq.insert(0, self.SPECB_QUE_BOS)
+                seq.append(self.SPECB_QUE_EOS)
+            else:
+                seq.insert(0, self.SPECB_DOC_BOS)
+                seq.append(self.SPECB_DOC_EOS)
+            att.insert(0, 1)
+            att.append(1)
+        
+        return self.tokenizer.pad(batch_tokens, padding=True, return_tensors="pt").to(self.device)
+
+    def _convert_table_to_string(self, table_data: Any) -> str:
+        """Convert table data to string representation"""
+        if not table_data or not isinstance(table_data, list):
+            return str(table_data)
+
+        string_rows = []
+        for i, row_items in enumerate(table_data):
+            if i == 0:
+                string_rows.append("Columns: " + " | ".join(map(str, row_items)))
+            else:
+                string_rows.append("Data: " + " | ".join(map(str, row_items)))
+        
+        return " \\n ".join(string_rows)
+
+    def _beam_search_retrieval(self, query: str, dataset_name: str, top_k: int) -> List[Tuple[str, str]]:
+        """Multi-hop beam search retrieval"""
+        stored_corpus = self.corpus_embeddings[dataset_name]
+        table_ids = stored_corpus["ids"]
+        corpus_embeddings = stored_corpus["embeddings"]
+        table_strings = stored_corpus["table_strings"]
+
+        if not table_ids or not corpus_embeddings:
+            return []
+
+        # init beam search
+        beams = [BeamState([], query, 0.0, 0)]
+        
+        for hop in range(self.max_hops):
+            new_beams = []
+            
+            for beam in beams:
+                if not beam.current_query.strip():
+                    new_beams.append(beam)
+                    continue
+                
+                query_embeddings = self._get_embeddings_batch([beam.current_query], is_query=True)
+                if not query_embeddings or not query_embeddings[0]:
+                    new_beams.append(beam)
+                    continue
+                
+                query_embedding = query_embeddings[0]
+                
+                similarities = []
+                for idx, doc_embedding in enumerate(corpus_embeddings):
+                    if idx not in beam.retrieved_tables and doc_embedding:
+                        sim = 1 - cosine(query_embedding, doc_embedding)
+                        similarities.append((idx, sim))
+                
+                if not similarities:
+                    new_beams.append(beam)
+                    continue
+                
+                similarities.sort(key=lambda x: x[1], reverse=True)
+                num_candidates = min(3, len(similarities))
+                
+                for table_idx, sim_score in similarities[:num_candidates]:
+                    new_retrieved = beam.retrieved_tables + [table_idx]
+                    beam_score = beam.score + sim_score
+                    
+                    rewritten_query = beam.current_query
+                    if self.use_rewriting:
+                        self._ensure_rewriter_client()
+                        rewritten_query = self._rewrite_query(
+                            beam.current_query, 
+                            [table_strings[table_idx]]
+                        )
+                    
+                    new_beams.append(BeamState(
+                        new_retrieved, rewritten_query, beam_score, hop + 1
+                    ))
+            
+            # prune beams
+            if new_beams:
+                new_beams.sort(key=lambda x: x.score, reverse=True)
+                beams = new_beams[:self.beam_size]
+            else:
+                break
+        
+        all_retrieved = set()
+        for beam in beams:
+            all_retrieved.update(beam.retrieved_tables)
+        
+        # return top_k 
+        table_scores = {}
+        for beam in beams:
+            for idx in beam.retrieved_tables:
+                if idx not in table_scores or beam.score > table_scores[idx]:
+                    table_scores[idx] = beam.score
+        
+        sorted_tables = sorted(table_scores.items(), key=lambda x: x[1], reverse=True)
+        results = []
+        for idx, _ in sorted_tables[:top_k]:
+            if idx < len(table_ids):
+                results.append(table_ids[idx])
+        
+        return results
+
+    def _single_hop_retrieval(self, query: str, dataset_name: str, top_k: int) -> List[Tuple[str, str]]:
+        """Single-hop retrieval fallback"""
+        stored_corpus = self.corpus_embeddings[dataset_name]
+        table_ids = stored_corpus["ids"]
+        corpus_embeddings = stored_corpus["embeddings"]
+
+        query_embeddings = self._get_embeddings_batch([query], is_query=True)
+        if not query_embeddings or not query_embeddings[0]:
+            return []
+        
+        query_embedding = query_embeddings[0]
+        
+        similarities = []
+        for doc_embedding in corpus_embeddings:
+            if doc_embedding:
+                sim = 1 - cosine(query_embedding, doc_embedding)
+                similarities.append(sim)
+            else:
+                similarities.append(0.0)
+        
+        top_indices = np.argsort(similarities)[::-1][:top_k]
+        return [table_ids[i] for i in top_indices]
+
+    def _rewrite_query(self, query: str, retrieved_table_strings: List[str]) -> str:
+        """Rewrite query by removing information about retrieved tables"""
+        try:
+            retrieved_info = "\n".join(retrieved_table_strings)
+            
+            prompt = f"""Given a user question and previously retrieved tables, rewrite the question by REMOVING information that is already covered by the retrieved tables.
+
+            Previously Retrieved Tables:
+            {retrieved_info}
+
+            Original Question: {query}
+
+            Task: Rewrite the question to focus on information NOT covered by the retrieved tables. If all necessary information is already covered, respond with "None".
+
+            Rewritten Question (or "None"):"""
+            
+            messages = [
+                ("system", "You are a helpful assistant for multi-hop table retrieval."),
+                ("user", prompt)
+            ]
+            
+            response = self.rewriter_client.invoke(messages)
+            rewritten_query = response.content.strip()
+            
+            # Check for early stopping
+            if any(signal in rewritten_query.lower() for signal in ["none", "no additional"]):
+                return ""
+            
+            return rewritten_query
+            
+        except Exception as e:
+            print(f"Warning: Query rewriting failed: {e}")
+            return query 

--- a/target_benchmark/retrievers/murre/MurreRetriever.py
+++ b/target_benchmark/retrievers/murre/MurreRetriever.py
@@ -84,7 +84,7 @@ class MurreRetriever(AbsCustomEmbeddingRetriever):
             self._load_embeddings(dataset_name)
         
         try:
-            if self.beam_size > 1:
+            if self.max_hops > 1:
                 return self._beam_search_retrieval(query, dataset_name, top_k)
             else:
                 return self._single_hop_retrieval(query, dataset_name, top_k)

--- a/target_benchmark/retrievers/murre/__init__.py
+++ b/target_benchmark/retrievers/murre/__init__.py
@@ -1,0 +1,3 @@
+from .MurreRetriever import MurreRetriever
+
+__all__ = ["MurreRetriever"]

--- a/target_benchmark/retrievers/murre/prompt/bird-validation/rewrite.txt
+++ b/target_benchmark/retrievers/murre/prompt/bird-validation/rewrite.txt
@@ -1,0 +1,42 @@
+Given the following SQL tables, your job is to complete the possible left SQL tables given a user's request.
+Return None if no left SQL tables according to the user's request.
+
+Quetsion: What was the growth rate of the total amount of loans across all accounts for a male client between 1996 and 1997?
+Database: financial.client(client_id, gender, birth_date, location of branch) \n financial.loan(loan_id, account_id, date, amount, duration, monthly payments, status)
+Completing Tables: financial.account(account id, location of branch, frequency, date) \n financial.disp(disposition id, client_id, account_id, type)
+
+Question: How many members did attend the event 'Community Theater' in 2019?
+Database: student_club.Attendance(link to event, link to member)
+Completing Tables: student_club.Event(event id, event name, event date, type, notes, location, status)
+
+Question: What's the Italian name of the set of cards with "Ancestor's Chosen" is in?
+Database: card_games.cards(unique id number identifying the cards, artist, ascii Name, availability, border Color, card Kingdom Foil Id, card Kingdom Id, color Identity, color Indicator, colors, converted Mana Cost) \n card_games.set_translations(id, language, set code, translation)
+Completing Tables: None
+
+Question: Which user have only one post history per post and having at least 1000 views?
+Database: codebase_community.postHistory(Id, Post History Type Id, Post Id, Creation Date, User Id, Text, Comment, User Display Name)
+Completing Tables: codebase_community.users(Id, Reputation, Creation Date, Display Name, Website Url, Location, Views, UpVotes, DownVotes, Account Id, Profile Image Url)
+
+Question: Among the atoms that contain element carbon, which one does not contain compound carcinogenic?
+Database: toxicology.atom(atom id, molecule id, element) \n toxicology.molecule(molecule id, label)
+Completing Tables: None
+
+Question: What is the percentage of the customers who used EUR in 2012/8/25?
+Database: debit_card_specializing.customers(CustomerID, client segment, Currency)
+Completing Tables: debit_card_specializing.transactions_1k(Transaction ID, Date, Time, Customer ID, Card ID, Gas Station ID, Product ID, Amount, Price)
+
+Question: For the drivers who took part in the race in 1983/7/16, what's their race completion rate?
+Database: formula_1.results(Result ID, race ID, driver ID, constructor Id, number, grid, position, points, laps, time, milliseconds, fastest lap, rank, status Id) \n formula_1.races(race ID, year, round, Circuit Id, name, date, time, url)
+Completing Tables: None
+
+Question: Please list the leagues from Germany.
+Database: european_football_2.League(id, country id, name)
+Completing Tables: european_football_2.Country(id, name)
+
+Question: Please list the zip code of all the charter schools in Fresno County Office of Education.
+Database: california_schools.schools(CDSCode, National Center for Educational Statistics school district identification number, National Center for Educational Statistics school identification number, StatusType, County, District, School, Street, street address, City, Zip, State, MailStreet, Charter)
+Completing Tables: california_schools.frpm(CDSCode, Academic Year, County Code, District Code, School Code, County Name, District Name, School Name, District Type, School Type, Educational Option Type, Charter School (Y/N), Charter School Number, Charter Funding Type, IRC, Enrollment (K-12))
+
+Question: {question}
+Database: {database}
+Completing Tables: 

--- a/target_benchmark/retrievers/murre/prompt/default/rewrite.txt
+++ b/target_benchmark/retrievers/murre/prompt/default/rewrite.txt
@@ -1,10 +1,2 @@
-Given a user question and previously retrieved tables, rewrite the question by REMOVING information that is already covered by the retrieved tables.
-
-Previously Retrieved Tables:
-{retrieved_info}
-
-Original Question: {query}
-
-Task: Rewrite the question to focus on information NOT covered by the retrieved tables. If all necessary information is already covered, respond with "None".
-
-Rewritten Question (or "None"): 
+Given the following SQL tables, your job is to complete the possible left SQL tables given a user's request.
+Return None if no left SQL tables according to the user's request.

--- a/target_benchmark/retrievers/murre/prompt/default/rewrite.txt
+++ b/target_benchmark/retrievers/murre/prompt/default/rewrite.txt
@@ -1,0 +1,10 @@
+Given a user question and previously retrieved tables, rewrite the question by REMOVING information that is already covered by the retrieved tables.
+
+Previously Retrieved Tables:
+{retrieved_info}
+
+Original Question: {query}
+
+Task: Rewrite the question to focus on information NOT covered by the retrieved tables. If all necessary information is already covered, respond with "None".
+
+Rewritten Question (or "None"): 

--- a/target_benchmark/retrievers/murre/prompt/spider-test/rewrite.txt
+++ b/target_benchmark/retrievers/murre/prompt/spider-test/rewrite.txt
@@ -1,0 +1,46 @@
+Given the following SQL tables, your job is to complete the possible left SQL tables given a user's request.
+Return None if no left SQL tables according to the user's request.
+
+Question: Which models are lighter than 3500 but not built by the 'Ford Motor Company'?
+Database: car_1.model list(model id, maker, model) \n car_1.cars data(id, mpg, cylinders, edispl, horsepower, weight, accelerate, year) \n car_1.car names(make id, model, make)
+Completing Tables: car_1.car makers(id, maker, full name, country)
+
+Question: Which employee received the biggest bonus? Give me the employee name.
+Database: employee_hire_evaluation.evaluation(employee id, year awarded, bonus) \n employee_hire_evaluation.employee(employee id, name, age, city)
+Completing Tables: None
+
+Question: What is the lowest grade of students who do not have any friends?
+Database: network_1.friend(student id, friend id) \n network_1.high schooler(id, name, grade)
+Completing Tables: None
+
+Question: Which airlines have a flight with destination airport AHD?
+Database: flight_2.flights(airline, flight number, source airport, destination airport)
+Completing Tables: flight_2.airlines(airline id, airline name, abbreviation, country)
+
+Question: What are the first names of all players, and their average rankings?
+Database: wta_1.players(player id, first name, last name, hand, birth date, country code) \n wta_1.rankings(ranking date, ranking, player id, ranking points, tours)
+Completing Tables: None
+
+Question: What are the codes of template types that are not used for any document?
+Database: cre_Doc_Template_Mgt.templates(template id, version number, template type code, date effective from, date effective to, template details)
+Completing Tables: cre_Doc_Template_Mgt.documents(document id, template id, document name, document description, other details)
+
+Question: Find the semester when both Master students and Bachelor students got enrolled in.
+Database: student_transcripts_tracking.student enrolment(student enrolment id, degree program id, semester id, student id, other details)
+Completing Tables: student_transcripts_tracking.degree programs(degree program id, department id, degree summary name, degree summary description)
+
+Question: What are the names of cities in Europe for which English is not the official language?
+Database: world_1.countrylanguage(countrycode, language, is official, percentage)
+Completing Tables: world_1.city(id, name, country code, district, population)
+
+Question: Show the name of the teacher for the math course.
+Database: course_teach.teacher(teacher id, name, age, hometown) \n course_teach.course(course id, staring date, course)
+Completing Tables: course_teach.course arrange(course id, teacher id, grade)
+
+Quetsion: What are the ids of the students who do not own cats as pets?
+Database: pets_1.has pet(student id, pet id) \n pets_1.student(student id, last name, first name, age, sex, major, advisor, city code)
+Completing Tables: pets_1.pets(pet id, pet type, pet age, weight)
+
+Question: {question}
+Database: {database}
+Completing Tables: 

--- a/tests/retrievers/murre_retriever_test.py
+++ b/tests/retrievers/murre_retriever_test.py
@@ -1,0 +1,117 @@
+import unittest
+import os
+
+from target_benchmark.evaluators.TARGET import TARGET
+from target_benchmark.retrievers.murre.MurreRetriever import MurreRetriever
+from target_benchmark.tasks import TableRetrievalTask
+
+
+# Similar to llama_index_basic_test.py
+class TestMurreBasics(unittest.TestCase):
+    def setUp(self):
+        self.fetaqa_dummy_config = {
+            "dataset_name": "fetaqa",
+            "hf_corpus_dataset_path": "jixy2012/mock-hf-corpus-dataset",
+            "hf_queries_dataset_path": "jixy2012/mock-hf-queries-dataset",
+            "query_type": "Table Question Answering",
+        }
+        self.trt = TableRetrievalTask({"fetaqa": self.fetaqa_dummy_config}, True)
+        self.evaluator = TARGET(downstream_tasks=self.trt)
+
+    def test_run_murre_on_dummy(self):
+        murre = MurreRetriever(
+            model="text-embedding-3-small",
+            embedding_type="openai",
+            use_rewriting=False,
+            beam_size=2,
+            max_hops=1
+        )
+
+        res = self.evaluator.run(murre)
+        self.assertIn("Table Retrieval Task", res)
+        print(res)
+
+    def test_murre_instance_creation(self):
+        
+        murre_default = MurreRetriever()
+        self.assertEqual(murre_default.model, "text-embedding-3-small")
+        self.assertEqual(murre_default.embedding_type, "openai")
+        self.assertEqual(murre_default.beam_size, 3)
+        self.assertEqual(murre_default.max_hops, 2)
+        self.assertFalse(murre_default.use_rewriting)
+        
+        murre_custom = MurreRetriever(
+            model="text-embedding-ada-002",
+            embedding_type="openai",
+            use_rewriting=True,
+            beam_size=5,
+            max_hops=3,
+            rewriter_model="gpt-4o"
+        )
+        self.assertEqual(murre_custom.model, "text-embedding-ada-002")
+        self.assertTrue(murre_custom.use_rewriting)
+        self.assertEqual(murre_custom.beam_size, 5)
+        self.assertEqual(murre_custom.max_hops, 3)
+        self.assertEqual(murre_custom.rewriter_model, "gpt-4o")
+
+    def test_table_conversion(self):
+        murre = MurreRetriever()
+        
+        table_data = [
+            ["Name", "Age", "City"],
+            ["John", "25", "New York"],
+            ["Jane", "30", "Los Angeles"]
+        ]
+        result = murre._convert_table_to_string(table_data)
+        expected = "Columns: Name | Age | City \\n Data: John | 25 | New York \\n Data: Jane | 30 | Los Angeles"
+        self.assertEqual(result, expected)
+        
+        empty_table = []
+        result_empty = murre._convert_table_to_string(empty_table)
+        self.assertEqual(result_empty, "[]")
+        
+        result_none = murre._convert_table_to_string(None)
+        self.assertEqual(result_none, "None")
+
+    @unittest.skipIf(not os.getenv("OPENAI_API_KEY"), "OpenAI API key not available")
+    def test_embedding_functionality(self):
+        murre = MurreRetriever(
+            model="text-embedding-3-small",
+            embedding_type="openai"
+        )
+        
+        murre._ensure_embedding_client()
+        self.assertIsNotNone(murre.embedding_client)
+        
+        test_texts = ["Sample table with data"]
+        embeddings = murre._get_embeddings_batch(test_texts, is_query=True)
+        
+        self.assertEqual(len(embeddings), 1)
+        self.assertEqual(len(embeddings[0]), 1536)  
+
+    def test_beam_state_creation(self):
+        from target_benchmark.retrievers.murre.MurreRetriever import BeamState
+        
+        beam = BeamState(
+            retrieved_tables=[1, 2, 3],
+            current_query="test query",
+            score=0.85,
+            hop=1
+        )
+        
+        self.assertEqual(beam.retrieved_tables, [1, 2, 3])
+        self.assertEqual(beam.current_query, "test query")
+        self.assertEqual(beam.score, 0.85)
+        self.assertEqual(beam.hop, 1)
+        
+        beam_none = BeamState(
+            retrieved_tables=None,
+            current_query="test",
+            score=0.0,
+            hop=0
+        )
+        self.assertEqual(beam_none.retrieved_tables, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add MurreRetriever based on the paper ["MurRe: Multi-Hop Table Retrieval with Removal for Open-Domain Text-to-SQL"](https://arxiv.org/pdf/2402.10666) by Zhang et al. 

The multi-hop logic is implemented in `_beam_search_retrieval()`. Each beam maintains a `BeamState` containing retrieved tables, current query, score, and hop count. 

When `use_rewriting=True`, the `_rewrite_query()` method uses an OpenAI LLM to remove information about already retrieved tables from the query. The pre prompt for the rewriting step is hardcoded for now but could be extracted in a separate configuration.

Supports both local embeddings and OpenAI embeddings, provided you have an API key set as the environment variable `OPENAI_API_KEY`. 

For SGPT models, SPECB tokens are handled following their original [MURRE repository](https://github.com/zhxlia/MURRE).


Example usage:

```python
retriever = MurreRetriever(
    embedding_type="openai",  # or "custom"
    beam_size=3,              # number of parallel search beams  
    max_hops=2,               # maximum retrieval hops
    use_rewriting=True     # enable query rewriting between hops
)
```
